### PR TITLE
Use uint64 for pointer return vars

### DIFF
--- a/pkg/wca/IAudioSessionControl2_windows.go
+++ b/pkg/wca/IAudioSessionControl2_windows.go
@@ -10,7 +10,7 @@ import (
 )
 
 func asc2GetSessionIdentifier(asc2 *IAudioSessionControl2, retVal *string) (err error) {
-	var retValPtr uint32
+	var retValPtr uint64
 	hr, _, _ := syscall.Syscall(
 		asc2.VTable().GetSessionIdentifier,
 		2,
@@ -37,7 +37,7 @@ func asc2GetSessionIdentifier(asc2 *IAudioSessionControl2, retVal *string) (err 
 }
 
 func asc2GetSessionInstanceIdentifier(asc2 *IAudioSessionControl2, retVal *string) (err error) {
-	var retValPtr uint32
+	var retValPtr uint64
 	hr, _, _ := syscall.Syscall(
 		asc2.VTable().GetSessionInstanceIdentifier,
 		2,

--- a/pkg/wca/IAudioSessionControl_windows.go
+++ b/pkg/wca/IAudioSessionControl_windows.go
@@ -23,7 +23,7 @@ func ascGetState(asc *IAudioSessionControl, retVal *uint32) (err error) {
 }
 
 func ascGetDisplayName(asc *IAudioSessionControl, retVal *string) (err error) {
-	var retValPtr uint32
+	var retValPtr uint64
 	hr, _, _ := syscall.Syscall(
 		asc.VTable().GetDisplayName,
 		2,
@@ -63,7 +63,7 @@ func ascSetDisplayName(asc *IAudioSessionControl, value *string, eventContext *o
 }
 
 func ascGetIconPath(asc *IAudioSessionControl, retVal *string) (err error) {
-	var retValPtr uint32
+	var retValPtr uint64
 	hr, _, _ := syscall.Syscall(
 		asc.VTable().GetIconPath,
 		2,

--- a/pkg/wca/IMMDevice_windows.go
+++ b/pkg/wca/IMMDevice_windows.go
@@ -41,7 +41,7 @@ func mmdOpenPropertyStore(mmd *IMMDevice, storageMode uint32, ps **IPropertyStor
 }
 
 func mmdGetId(mmd *IMMDevice, strId *string) (err error) {
-	var strIdPtr uint32
+	var strIdPtr uint64
 	hr, _, _ := syscall.Syscall(
 		mmd.VTable().GetId,
 		2,


### PR DESCRIPTION
fixes #8

NOTE:

- I only tested the `mmdGetId` fix, but since the code in the other places is pretty much the same I'd expect it to work there as well.
- I tried building my test app with `GOARCH=386` and it still worked, so I guess uint64 with 32-bit pointers isn't a problem.