### PR TITLE
fixing typo in AusioSessionState constants

### DIFF
--- a/pkg/wca/constants.go
+++ b/pkg/wca/constants.go
@@ -164,7 +164,7 @@ const (
 )
 
 const (
-	AudioSessionStateActive = iota
-	AudioSessionStateInactive
+	AudioSessionStateInactive = iota
+	AudioSessionStateActive
 	AudioSessionStateExpired
 )


### PR DESCRIPTION
There was an typo in the AudioSessionState costants, now they are in line with the documentation: https://docs.microsoft.com/en-us/windows/win32/api/audiosessiontypes/ne-audiosessiontypes-audiosessionstate