### PR TITLE
Update go-ole/go-ole to v1.2.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/moutend/go-wca
 
 go 1.13
 
-require github.com/go-ole/go-ole v1.2.4
+require github.com/go-ole/go-ole v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
+github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
+github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3 h1:7TYNF4UdlohbFwpNH04CoPMp1cHUZgO1Ebq5r2hIjfo=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/wca/IAudioCaptureClient_func.go
+++ b/pkg/wca/IAudioCaptureClient_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioCaptureClient_windows.go
+++ b/pkg/wca/IAudioCaptureClient_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IAudioClient2_func.go
+++ b/pkg/wca/IAudioClient2_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioClient2_windows.go
+++ b/pkg/wca/IAudioClient2_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IAudioClient3_func.go
+++ b/pkg/wca/IAudioClient3_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioClient3_windows.go
+++ b/pkg/wca/IAudioClient3_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IAudioClient_func.go
+++ b/pkg/wca/IAudioClient_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioClient_windows.go
+++ b/pkg/wca/IAudioClient_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IAudioEndpointVolume_func.go
+++ b/pkg/wca/IAudioEndpointVolume_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioEndpointVolume_windows.go
+++ b/pkg/wca/IAudioEndpointVolume_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IAudioMeterInformation_func.go
+++ b/pkg/wca/IAudioMeterInformation_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioMeterInformation_windows.go
+++ b/pkg/wca/IAudioMeterInformation_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IAudioRenderClient_func.go
+++ b/pkg/wca/IAudioRenderClient_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioRenderClient_windows.go
+++ b/pkg/wca/IAudioRenderClient_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IAudioSessionControl2_func.go
+++ b/pkg/wca/IAudioSessionControl2_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioSessionControl2_windows.go
+++ b/pkg/wca/IAudioSessionControl2_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IAudioSessionControl_func.go
+++ b/pkg/wca/IAudioSessionControl_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioSessionControl_windows.go
+++ b/pkg/wca/IAudioSessionControl_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IAudioSessionEnumerator_func.go
+++ b/pkg/wca/IAudioSessionEnumerator_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioSessionEnumerator_windows.go
+++ b/pkg/wca/IAudioSessionEnumerator_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IAudioSessionManager2_func.go
+++ b/pkg/wca/IAudioSessionManager2_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioSessionManager2_windows.go
+++ b/pkg/wca/IAudioSessionManager2_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IAudioSessionManager_func.go
+++ b/pkg/wca/IAudioSessionManager_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IAudioSessionManager_windows.go
+++ b/pkg/wca/IAudioSessionManager_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IMMDeviceCollection_func.go
+++ b/pkg/wca/IMMDeviceCollection_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IMMDeviceCollection_windows.go
+++ b/pkg/wca/IMMDeviceCollection_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IMMDeviceEnumerator_func.go
+++ b/pkg/wca/IMMDeviceEnumerator_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IMMDeviceEnumerator_windows.go
+++ b/pkg/wca/IMMDeviceEnumerator_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IMMDevice_func.go
+++ b/pkg/wca/IMMDevice_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IMMDevice_windows.go
+++ b/pkg/wca/IMMDevice_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IMMEndpoint_func.go
+++ b/pkg/wca/IMMEndpoint_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IMMEndpoint_windows.go
+++ b/pkg/wca/IMMEndpoint_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IMMNotificationClient_windows.go
+++ b/pkg/wca/IMMNotificationClient_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/IPropertyStore_func.go
+++ b/pkg/wca/IPropertyStore_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/IPropertyStore_windows.go
+++ b/pkg/wca/IPropertyStore_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/ISimpleAudioVolume_func.go
+++ b/pkg/wca/ISimpleAudioVolume_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/ISimpleAudioVolume_windows.go
+++ b/pkg/wca/ISimpleAudioVolume_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/PROPVARIANT_func.go
+++ b/pkg/wca/PROPVARIANT_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/PROPVARIANT_windows.go
+++ b/pkg/wca/PROPVARIANT_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wca

--- a/pkg/wca/com_func.go
+++ b/pkg/wca/com_func.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package wca

--- a/pkg/wca/com_windows.go
+++ b/pkg/wca/com_windows.go
@@ -1,4 +1,6 @@
+//go:build windows
 // +build windows
+
 package wca
 
 import (


### PR DESCRIPTION
I've updated go-ole/go-ole to v1.2.6.

Also I've applied `go fmt` to the codes on this repository.

Additionally, I've verified the pkg/wca can build with the latest version of go, v1.20.1.