### PR TITLE
Fix `BIsOffload` type in `AudioClientProperties` struct

### DIFF
--- a/pkg/wca/AudioClientProperties.go
+++ b/pkg/wca/AudioClientProperties.go
@@ -2,7 +2,7 @@ package wca
 
 type AudioClientProperties struct {
 	CbSize                uint32
-	BIsOffload            bool
+	BIsOffload            int32
 	AUDIO_STREAM_CATEGORY uint32
 	AUDCLNT_STREAMOPTIONS uint32
 }


### PR DESCRIPTION
The `bool` type for `BIsOffload` is incorrect for this field since `BOOL` in Windows is defined as an int (4 bytes), but it's just 1 byte in Golang.

https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types